### PR TITLE
CRLF&LF mixed in some files. Cleanup.

### DIFF
--- a/pyfpdb/Archive.py
+++ b/pyfpdb/Archive.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 #    Copyright 2012, Chaz Littlejohn
 #    
 #    This program is free software; you can redistribute it and/or modify

--- a/pyfpdb/BetOnlineToFpdb.py
+++ b/pyfpdb/BetOnlineToFpdb.py
@@ -2,17 +2,17 @@
 # -*- coding: utf-8 -*-
 #
 #    Copyright 2008-2011, Chaz Littlejohn
-#    
+#
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
 #    (at your option) any later version.
-#    
+#
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 #    GNU General Public License for more details.
-#    
+#
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -44,7 +44,7 @@ class BetOnline(HandHistoryConverter):
                      'PLYR': r'(?P<PNAME>.+?)',
                      'NUM' :u".,\d",
                     }
-                    
+
     # translations from captured groups to fpdb info strings
     Lim_Blinds = {  '0.04': ('0.01', '0.02'),        '0.08': ('0.02', '0.04'),
                         '0.10': ('0.02', '0.05'),    '0.20': ('0.05', '0.10'),
@@ -69,10 +69,10 @@ class BetOnline(HandHistoryConverter):
 
     limits = { 'No Limit':'nl', 'Pot Limit':'pl', 'Limit':'fl', 'LIMIT':'fl' }
     games = {                          # base, category
-                              "Hold'em" : ('hold','holdem'), 
+                              "Hold'em" : ('hold','holdem'),
                                 'Omaha' : ('hold','omahahi'),
                           'Omaha Hi/Lo' : ('hold','omahahilo'),
-                                 'Razz' : ('stud','razz'), 
+                                 'Razz' : ('stud','razz'),
                           '7 Card Stud' : ('stud','studhi'),
                     '7 Card Stud Hi/Lo' : ('stud','studhilo'),
                                'Badugi' : ('draw','badugi'),
@@ -90,7 +90,7 @@ class BetOnline(HandHistoryConverter):
                            'Triple Stud': '3stud'
                } # Legal mixed games
     currencies = { u'€':'EUR', '$':'USD', '':'T$' }
-    
+
     skins = {
                        'BetOnline Poker': 'BetOnline',
                              'PayNoRake': 'PayNoRake',
@@ -124,20 +124,20 @@ class BetOnline(HandHistoryConverter):
     re_PlayerInfo   = re.compile(u"""
           ^Seat\s(?P<SEAT>[0-9]+):\s
           (?P<PNAME>.*)\s
-          \((%(LS)s)?(?P<CASH>[%(NUM)s]+)\sin\s[cC]hips\)""" % substitutions, 
+          \((%(LS)s)?(?P<CASH>[%(NUM)s]+)\sin\s[cC]hips\)""" % substitutions,
           re.MULTILINE|re.VERBOSE)
 
     re_HandInfo1     = re.compile("""
           ^Table\s\'(?P<TABLE>[\/,\.\-\ &%\$\#a-zA-Z\d\'\(\)]+)\'\s
           ((?P<MAX>\d+)-max\s)?
           (?P<MONEY>\((Play\sMoney|Real\sMoney)\)\s)?
-          (Seat\s\#(?P<BUTTON>\d+)\sis\sthe\sbutton)?""", 
+          (Seat\s\#(?P<BUTTON>\d+)\sis\sthe\sbutton)?""",
           re.MULTILINE|re.VERBOSE)
-    
+
     re_HandInfo2     = re.compile("""
           ^Table\s(?P<TABLE>[\/,\.\-\ &%\$\#a-zA-Z\d\']+)\s
           (?P<MONEY>\((Play\sMoney|Real\sMoney)\)\s)?
-          (Seat\s\#(?P<BUTTON>\d+)\sis\sthe\sbutton)?""", 
+          (Seat\s\#(?P<BUTTON>\d+)\sis\sthe\sbutton)?""",
           re.MULTILINE|re.VERBOSE)
 
     re_Identify     = re.compile(u'(BetOnline\sPoker|PayNoRake|ActionPoker\.com|Gear\sPoker|SportsBetting\.ag\sPoker|Tiger\sGaming)\sGame\s\#\d+')
@@ -146,7 +146,7 @@ class BetOnline(HandHistoryConverter):
     re_Button       = re.compile('Seat #(?P<BUTTON>\d+) is the button', re.MULTILINE)
     re_Board1        = re.compile(r"Board \[(?P<FLOP>\S\S\S? \S\S\S? \S\S\S?)?\s?(?P<TURN>\S\S\S?)?\s?(?P<RIVER>\S\S\S?)?\]")
     re_Board2        = re.compile(r"\[(?P<CARDS>.+)\]")
-    
+
 
 
     re_DateTime1     = re.compile("""(?P<Y>[0-9]{4})\/(?P<M>[0-9]{2})\/(?P<D>[0-9]{2})[\- ]+(?P<H>[0-9]+):(?P<MIN>[0-9]+)(:(?P<S>[0-9]+))?\s(?P<TZ>.*$)""", re.MULTILINE)
@@ -191,7 +191,7 @@ class BetOnline(HandHistoryConverter):
                 ["tour", "hold", "fl"],
 
                 #["tour", "stud", "fl"],
-                
+
                 #["tour", "draw", "fl"],
                 #["tour", "draw", "pl"],
                 #["tour", "draw", "nl"],
@@ -234,7 +234,7 @@ class BetOnline(HandHistoryConverter):
             info['currency'] = 'USD'
         if 'MIXED' in mg:
             if mg['MIXED'] is not None: info['mix'] = self.mixes[mg['MIXED']]
-                
+
         if 'TOURNO' in mg and mg['TOURNO'] is None:
             info['type'] = 'ring'
         else:
@@ -276,7 +276,7 @@ class BetOnline(HandHistoryConverter):
                 #2008/11/12 10:00:48 CET [2008/11/12 4:00:48 ET] # (both dates are parsed so ET date overrides the other)
                 #2008/08/17 - 01:14:43 (ET)
                 #2008/09/07 06:23:14 ET
-                
+
                 datetimestr, time_zone = "2000/01/01 00:00:00", 'ET'  # default used if time not found
                 if self.skin not in ('ActionPoker', 'GearPoker'):
                     m1 = self.re_DateTime1.finditer(info[key])
@@ -358,7 +358,7 @@ class BetOnline(HandHistoryConverter):
                 hand.maxseats = int(info[key])
         if not self.re_Board1.search(hand.handText) and self.skin not in ('ActionPoker', 'GearPoker'):
             raise FpdbHandPartial("readHandInfo: " + _("Partial hand history") + ": '%s'" % hand.handid)
-    
+
     def readButton(self, hand):
         m = self.re_Button.search(hand.handText)
         if m:
@@ -375,7 +375,7 @@ class BetOnline(HandHistoryConverter):
     def markStreets(self, hand):
 
         # There is no marker between deal and draw in Stars single draw games
-        #  this upsets the accounting, incorrectly sets handsPlayers.cardxx and 
+        #  this upsets the accounting, incorrectly sets handsPlayers.cardxx and
         #  in consequence the mucked-display is incorrect.
         # Attempt to fix by inserting a DRAW marker into the hand text attribute
 
@@ -455,13 +455,13 @@ class BetOnline(HandHistoryConverter):
         for player in m:
             pname = self.unknownPlayer(hand, a.group('PNAME'))
             hand.addAnte(pname, self.clearMoneyString(player.group('ANTE')))
-    
+
     def readBringIn(self, hand):
         m = self.re_BringIn.search(hand.handText,re.DOTALL)
         if m:
             #~ logging.debug("readBringIn: %s for %s" %(m.group('PNAME'),  m.group('BRINGIN')))
             hand.addBringIn(m.group('PNAME'),  self.clearMoneyString(m.group('BRINGIN')))
-        
+
     def readBlinds(self, hand):
         liveBlind = True
         for a in self.re_PostSB.finditer(hand.handText):
@@ -492,7 +492,7 @@ class BetOnline(HandHistoryConverter):
             amount = str(Decimal(sbbb) + Decimal(sbbb)/2)
             hand.addBlind(pname, 'both', amount)
         self.fixActionBlinds(hand)
-                
+
     def fixActionBlinds(self, hand):
         # FIXME
         # The following should only trigger when a small blind is missing in ActionPoker hands, or the sb/bb is ALL_IN
@@ -510,7 +510,7 @@ class BetOnline(HandHistoryConverter):
                     hand.gametype['bb'] = str(int(Decimal(hand.gametype['sb']))*2)
                 else:
                     hand.gametype['sb'] = str(int(Decimal(hand.gametype['bb']))/2)
-            
+
     def unknownPlayer(self, hand, pname):
         if pname == 'Unknown player' or not pname:
             if not pname: pname = 'Dead'
@@ -582,7 +582,7 @@ class BetOnline(HandHistoryConverter):
 
     def readShowdownActions(self, hand):
 # TODO: pick up mucks also??
-        for shows in self.re_ShowdownAction.finditer(hand.handText):            
+        for shows in self.re_ShowdownAction.finditer(hand.handText):
             cards = shows.group('CARDS').split(' ')
             cards = [c[:-1].replace('10', 'T') + c[-1].lower() for c in cards]
             hand.addShownCards(cards, shows.group('PNAME'))

--- a/pyfpdb/BovadaSummary.py
+++ b/pyfpdb/BovadaSummary.py
@@ -27,7 +27,7 @@ from TourneySummary import *
 import BovadaToFpdb
 
 class BovadaSummary(TourneySummary):
-    
+
     substitutions = {
                          'LEGAL_ISO' : "USD",      # legal ISO currency codes
                                 'LS' : u"\$|", # legal currency symbols - Euro(cp1252, utf-8)
@@ -36,18 +36,18 @@ class BovadaSummary(TourneySummary):
                                 'NUM' :u".,\d",
                         }
     codepage = ("utf8", "cp1252")
-    
+
     re_Identify = re.compile(u'(Bovada|Bodog(\sUK|\sCanada|88)?)\sHand')
     re_AddOn = re.compile(r"^%(PLYR)s  ?\[ME\] : Addon (?P<ADDON>[%(NUM)s]+)" % substitutions, re.MULTILINE)
     re_Rebuyin = re.compile(r"%(PLYR)s  ?\[ME\] : Rebuyin (?P<REBUY>[%(NUM)s]+)" % substitutions, re.MULTILINE)
     re_Ranking = re.compile(r"%(PLYR)s  ?\[ME\] : Ranking (?P<RANK>[%(NUM)s]+)" % substitutions, re.MULTILINE)
-    re_Winnings = re.compile(r"%(PLYR)s  ?\[ME\] : Prize Cash \[(?P<WINNINGS>%(CUR)s[%(NUM)s]+)\]" % substitutions, re.MULTILINE)   
-    
+    re_Winnings = re.compile(r"%(PLYR)s  ?\[ME\] : Prize Cash \[(?P<WINNINGS>%(CUR)s[%(NUM)s]+)\]" % substitutions, re.MULTILINE)
+
     @staticmethod
     def getSplitRe(self, head):
         re_SplitTourneys = re.compile("PokerStars Tournament ")
         return re_SplitTourneys
-    
+
     def parseSummary(self):
         obj = getattr(BovadaToFpdb, "Bovada", None)
         hhc = obj(self.config, in_path = self.in_path, sitename = None, autostart = False)
@@ -56,12 +56,12 @@ class BovadaSummary(TourneySummary):
             tmp = self.summaryText[0:200]
             log.error(_("BovadaSummary.parseSummary: '%s'") % tmp)
             raise FpdbParseError
-        
+
         info = {}
         info.update(m.groupdict())
         m = hhc.re_Buyin.search(self.in_path)
         if m: info.update(m.groupdict())
-        
+
         if info['TOURNO'] is None:
             tmp = self.summaryText[0:200]
             log.error(_("BovadaSummary.parseSummary: Text does not appear to be a tournament '%s'") % tmp)
@@ -75,11 +75,11 @@ class BovadaSummary(TourneySummary):
                     self.gametype['limitType'] = hhc.limits[info['LIMIT']]
             if 'GAME' in info:
                 self.gametype['category'] = hhc.games[info['GAME']][1]
-                 
+
             if 'CURRENCY' in info and info['CURRENCY']:
                 self.buyinCurrency = hhc.currencies[info['CURRENCY']]
             self.currency = self.buyinCurrency
-            
+
             if 'DATETIME' in info and info['CURRENCY'] is not None:
                 m1 = hhc.re_DateTime.finditer(info['DATETIME'])
                 datetimestr = "2000/01/01 00:00:00"  # default used if time not found
@@ -89,15 +89,15 @@ class BovadaSummary(TourneySummary):
                     #print "   tz = ", tz, " datetime =", datetimestr
                 self.startTime = datetime.datetime.strptime(datetimestr, "%Y/%m/%d %H:%M:%S") # also timezone at end, e.g. " ET"
                 self.startTime = HandHistoryConverter.changeTimezone(self.startTime, "ET", "UTC")
-                
+
             self.buyin = 0
             self.fee   = 0
             self.prizepool = None
             self.entries   = None
-            
+
             if self.currency is None:
                 self.buyinCurrency = "FREE"
-            
+
             if 'BUYIN' in info and info['BUYIN'] is not None:
                 if info['BIAMT'] is not None and info['BIRAKE'] is not None:
                     if info['BUYIN'].find("$")!=-1:
@@ -110,7 +110,7 @@ class BovadaSummary(TourneySummary):
                     self.currency = self.buyinCurrency
 
                     info['BIAMT'] = info['BIAMT'].strip(u'$')
-                    
+
                     if info['BIRAKE']:
                         info['BIRAKE'] = info['BIRAKE'].strip(u'$')
                     else:
@@ -118,36 +118,36 @@ class BovadaSummary(TourneySummary):
 
                     self.buyin = int(100*Decimal(info['BIAMT']))
                     self.fee = int(100*Decimal(info['BIRAKE']))
-                    
+
                     if info['TOURNAME'] is not None:
                         tourneyNameFull = info['TOURNAME'] + ' - ' + info['BIAMT'] + '+' + info['BIRAKE']
                         self.tourneyName = tourneyNameFull
-                        
+
                         if 'TOURNAME' in info and 'Rebuy' in info['TOURNAME']:
                             self.isAddOn, self.isRebuy = True, True
                             self.rebuyCost = self.buyin
                             self.addOnCost = self.buyin
-            
+
             rank, winnings, rebuys, addons = None, None, 0, 0
-            
+
             m = self.re_Ranking.search(self.summaryText)
-            if m and m.group('RANK') is not None: 
+            if m and m.group('RANK') is not None:
                 rank = int(m.group('RANK'))
                 winnings = 0
-                
+
             m = self.re_Winnings.search(self.summaryText)
-            if m and m.group('WINNINGS') is not None: 
+            if m and m.group('WINNINGS') is not None:
                 if m.group('WINNINGS').find("$")!=-1:
                     self.currency="USD"
                 elif re.match("^[0-9+]*$", m.group('WINNINGS')):
                     self.currency="play"
                 winnings = int(100*Decimal(self.clearMoneyString(m.group('WINNINGS'))))
-                
+
             m = self.re_Rebuyin.finditer(self.summaryText)
             for a in m: rebuys += 1
-                
+
             m = self.re_AddOn.finditer(self.summaryText)
             for a in m: addons += 1
-                            
+
             self.addPlayer(rank, 'Hero', winnings, self.currency, rebuys, addons, 0)
-        
+

--- a/pyfpdb/BovadaToFpdb.py
+++ b/pyfpdb/BovadaToFpdb.py
@@ -2,17 +2,17 @@
 # -*- coding: utf-8 -*-
 #
 #    Copyright 2008-2012, Chaz Littlejohn
-#    
+#
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
 #    (at your option) any later version.
-#    
+#
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 #    GNU General Public License for more details.
-#    
+#
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -46,9 +46,9 @@ class Bovada(HandHistoryConverter):
                             'CUR': u"(\$|)",
                             'NUM' :u".,\d",
                     }
-                    
+
     # translations from captured groups to fpdb info strings
-    Lim_Blinds = {      '0.04': ('0.01', '0.02'),        
+    Lim_Blinds = {      '0.04': ('0.01', '0.02'),
                         '0.08': ('0.02', '0.04'),         '0.10': ('0.02', '0.05'),
                         '0.20': ('0.05', '0.10'),         '0.25': ('0.05', '0.10'),
                         '0.40': ('0.10', '0.20'),         '0.50': ('0.10', '0.25'),
@@ -79,7 +79,7 @@ class Bovada(HandHistoryConverter):
                       'HOLDEMZonePoker' : ('hold','holdem'),
                        'OMAHAZonePoker' : ('hold','omahahi'),
                   'OMAHA HiLoZonePoker' : ('hold','omahahilo'),
-                      
+
                }
     currencies = {'$':'USD', '':'T$'}
 
@@ -88,10 +88,10 @@ class Bovada(HandHistoryConverter):
           (Bovada|Bodog(\sUK|\sCanada|88)?)\sHand\s\#C?(?P<HID>[0-9]+):?\s+
           ((?P<ZONE>Zone\sPoker\sID|TBL)\#(?P<TABLE>.+?)\s)?
           (?P<GAME>HOLDEM|OMAHA|OMAHA_HL|7CARD|7CARD\sHiLo|OMAHA\sHiLo|7CARD_HL|HOLDEMZonePoker|OMAHAZonePoker|OMAHA\sHiLoZonePoker)\s+
-          (Tournament\s\#                # open paren of tournament info Tournament #2194767 TBL#1, 
+          (Tournament\s\#                # open paren of tournament info Tournament #2194767 TBL#1,
           (?P<TOURNO>\d+)\sTBL\#(?P<TABLENO>\d+),
           \s)?
-          (?P<HU>1\son\s1\s)? 
+          (?P<HU>1\son\s1\s)?
           (?P<LIMIT>No\sLimit|Fixed\sLimit|Pot\sLimit)?
           (\s?Normal\s?)?
           (-\sLevel\s\d+?\s
@@ -108,13 +108,13 @@ class Bovada(HandHistoryConverter):
     re_PlayerInfo   = re.compile(u"""
           ^Seat\s(?P<SEAT>[0-9]+):\s
           %(PLYR)s\s(?P<HERO>\[ME\]\s)?
-          \((%(LS)s)?(?P<CASH>[%(NUM)s]+)\sin\schips\)""" % substitutions, 
+          \((%(LS)s)?(?P<CASH>[%(NUM)s]+)\sin\schips\)""" % substitutions,
           re.MULTILINE|re.VERBOSE)
-    
+
     re_PlayerInfoStud   = re.compile(u"""
           ^(?P<PNAME>Seat\+(?P<SEAT>[0-9]+))
           (?P<HERO>\s\[ME\])?:\s
-          (%(LS)s)?(?P<CASH>[%(NUM)s]+)\sin\schips""" % substitutions, 
+          (%(LS)s)?(?P<CASH>[%(NUM)s]+)\sin\schips""" % substitutions,
           re.MULTILINE|re.VERBOSE)
 
     re_Identify     = re.compile(u'(Bovada|Bodog(\sUK|\sCanada|88)?)\sHand')
@@ -145,7 +145,7 @@ class Bovada(HandHistoryConverter):
     re_Hole_Third       = re.compile(r"\*\*\*\s(3RD\sSTREET|HOLE\sCARDS)\s\*\*\*")
     re_ReturnBet        = re.compile(r"Return\suncalled\sportion", re.MULTILINE)
     #Small Blind : Hand result $19
-    
+
     def compilePlayerRegexs(self,  hand):
         pass
 
@@ -153,29 +153,29 @@ class Bovada(HandHistoryConverter):
         return [["ring", "hold", "nl"],
                 ["ring", "hold", "pl"],
                 ["ring", "hold", "fl"],
-                
+
                 ["ring", "stud", "fl"],
-                
+
                 ["tour", "hold", "nl"],
                 ["tour", "hold", "pl"],
                 ["tour", "hold", "fl"],
-                
+
                 ["tour", "stud", "fl"],
                 ]
 
     def determineGameType(self, handText):
-        info = {}            
+        info = {}
         m = self.re_GameInfo.search(handText)
         if not m:
             tmp = handText[0:200]
             log.error(_("BovadaToFpdb.determineGameType: '%s'") % tmp)
             raise FpdbParseError
-        
+
         m1 = self.re_Dealt.search(handText)
         m2 = self.re_Summary.search(handText)
         if not m1 or not m2:
             raise FpdbHandPartial("BovadaToFpdb.determineGameType: " + _("Partial hand history"))
-        
+
         mg = m.groupdict()
         m = self.re_Stakes.search(self.in_path)
         if m: mg.update(m.groupdict())
@@ -187,27 +187,27 @@ class Bovada(HandHistoryConverter):
                 info['limitType'] = self.limits[mg['LIMIT']]
         if 'GAME' in mg:
             (info['base'], info['category']) = self.games[mg['GAME']]
-            
+
         if 'SB' in mg:
             info['sb'] = self.clearMoneyString(mg['SB'])
         if 'BB' in mg:
             info['bb'] = self.clearMoneyString(mg['BB'])
-            
+
         if 'TOURNO' in mg and mg['TOURNO'] is not None:
             info['type'] = 'tour'
             info['currency'] = 'T$'
         else:
             info['type'] = 'ring'
             info['currency'] = 'USD'
-             
+
         if 'CURRENCY' in mg and mg['CURRENCY'] is not None:
             info['currency'] = self.currencies[mg['CURRENCY']]
-            
+
         if 'Zone' in mg['GAME']:
             info['fast'] = True
         else:
             info['fast'] = False
-            
+
         if info['limitType'] == 'fl' and info['bb'] is not None:
             if info['type'] == 'ring':
                 try:
@@ -219,7 +219,7 @@ class Bovada(HandHistoryConverter):
                     raise FpdbParseError
             else:
                 info['sb'] = str((Decimal(info['sb'])/2).quantize(Decimal("0.01")))
-                info['bb'] = str(Decimal(info['sb']).quantize(Decimal("0.01")))   
+                info['bb'] = str(Decimal(info['sb']).quantize(Decimal("0.01")))
 
         return info
 
@@ -230,12 +230,12 @@ class Bovada(HandHistoryConverter):
             tmp = hand.handText[0:200]
             log.error(_("BovadaToFpdb.readHandInfo: '%s'") % tmp)
             raise FpdbParseError
-        
+
         info.update(m.groupdict())
         m = self.re_Buyin.search(self.in_path)
         if m: info.update(m.groupdict())
         hand.allInBlind = False
-        
+
         for key in info:
             if key == 'DATETIME':
                 m1 = self.re_DateTime.finditer(info[key])
@@ -267,7 +267,7 @@ class Bovada(HandHistoryConverter):
                             raise FpdbParseError
 
                         info['BIAMT'] = info['BIAMT'].strip(u'$')
-                        
+
                         if info['BIRAKE']:
                             info['BIRAKE'] = info['BIRAKE'].strip(u'$')
                         else:
@@ -282,15 +282,15 @@ class Bovada(HandHistoryConverter):
                 elif info['ZONE'] and 'Zone' in info['ZONE']:
                     hand.tablename = info['ZONE'] + ' ' +info[key]
                 else:
-                    hand.tablename = info[key]        
+                    hand.tablename = info[key]
             if key == 'MAX' and info[key] != None:
                 hand.maxseats = int(info[key])
             if key == 'HU' and info[key] != None:
                 hand.maxseats = 2
-                
+
         if not hand.maxseats:
-            hand.maxseats = 9          
-    
+            hand.maxseats = 9
+
     def readButton(self, hand):
         m = self.re_Button.search(hand.handText)
         if m:
@@ -317,13 +317,13 @@ class Bovada(HandHistoryConverter):
             raise FpdbParseError
         elif len(hand.players)==10:
             hand.maxseats = 10
-        
+
     def playerSeatFromPosition(self, source, handid, position):
         player = self.playersMap.get(position)
         if player is None:
             log.error(_("Hand.%s: '%s' unknown player seat from position: '%s'") % (source, handid, position))
             raise FpdbParseError
-        return player            
+        return player
 
     def markStreets(self, hand):
         # PREFLOP = ** Dealing down cards **
@@ -331,7 +331,7 @@ class Bovada(HandHistoryConverter):
         if hand.gametype['base'] == "hold":
             street, firststreet = 'PREFLOP', 'PREFLOP'
         else:
-            street, firststreet = 'THIRD', 'THIRD'  
+            street, firststreet = 'THIRD', 'THIRD'
         m = self.re_Action.finditer(self.re_Hole_Third.split(hand.handText)[0])
         allinblind = 0
         for action in m:
@@ -368,7 +368,7 @@ class Bovada(HandHistoryConverter):
                 if streetno < len(hand.actionStreets):
                     street = hand.actionStreets[streetno]
                 streetactions, players, bets = 0, contenders, 0
-                
+
         if not hand.streets.get(firststreet):
             hand.streets[firststreet] = hand.handText
         if hand.gametype['base'] == "hold":
@@ -376,7 +376,7 @@ class Bovada(HandHistoryConverter):
             for street in ('FLOP', 'TURN', 'RIVER'):
                 if m1 and m1.group(street) and not hand.streets.get(street):
                     hand.streets[street] = m1.group(street)
-            
+
 
     def readCommunityCards(self, hand, street): # street has been matched by markStreets, so exists in this hand
         if street in ('FLOP','TURN','RIVER'):   # a list of streets which get dealt community cards (i.e. all but PREFLOP)
@@ -390,18 +390,18 @@ class Bovada(HandHistoryConverter):
         for a in m:
             player = self.playerSeatFromPosition('BovadaToFpdb.readAntes', hand.handid, a.group('PNAME'))
             hand.addAnte(player, self.clearMoneyString(a.group('ANTE')))
-    
+
     def readBringIn(self, hand):
         m = self.re_BringIn.search(hand.handText,re.DOTALL)
         if m:
             #~ logging.debug("readBringIn: %s for %s" %(m.group('PNAME'),  m.group('BRINGIN')))
             player = self.playerSeatFromPosition('BovadaToFpdb.readBringIn', hand.handid, m.group('PNAME'))
             hand.addBringIn(player,  self.clearMoneyString(m.group('BRINGIN')))
-            
+
         if hand.gametype['sb'] == None and hand.gametype['bb'] == None:
             hand.gametype['sb'] = "1"
             hand.gametype['bb'] = "2"
-        
+
     def readBlinds(self, hand):
         sb, bb = None, None
         if not self.re_ReturnBet.search(hand.handText):
@@ -447,9 +447,9 @@ class Bovada(HandHistoryConverter):
             player = self.playerSeatFromPosition('BovadaToFpdb.readBlinds.postBoth', hand.handid, a.group('PNAME'))
             hand.addBlind(player, 'both', self.clearMoneyString(a.group('SBBB')))
             self.allInBlind(hand, 'PREFLOP', a, 'both')
-        
-        
-        
+
+
+
     def fixBlinds(self, hand):
         # See http://sourceforge.net/apps/mantisbt/fpdb/view.php?id=115
         if hand.gametype['sb'] == None and hand.gametype['bb'] == None:
@@ -477,7 +477,7 @@ class Bovada(HandHistoryConverter):
                     hand.hero = 'Hero'
                     newcards = found.group('NEWCARDS').split(' ')
                     hand.addHoleCards(street, hand.hero, closed=newcards, shown=False, mucked=False, dealt=True)
-                    
+
         for street, text in hand.streets.iteritems():
             if not text or street in ('PREFLOP', 'DEAL'): continue  # already done these
             m = self.re_ShowdownAction.finditer(hand.streets[street])
@@ -528,7 +528,7 @@ class Bovada(HandHistoryConverter):
                 pass
             else:
                 print (_("DEBUG:") + " " + _("Unimplemented %s: '%s' '%s'") % ("readAction", action.group('PNAME'), action.group('ATYPE')))
-                
+
     def allInBlind(self, hand, street, action, actiontype):
         if street in ('PREFLOP', 'DEAL'):
             player = self.playerSeatFromPosition('BovadaToFpdb.allInBlind', hand.handid, action.group('PNAME'))
@@ -539,7 +539,7 @@ class Bovada(HandHistoryConverter):
     def readShowdownActions(self, hand):
 # TODO: pick up mucks also??
         if hand.gametype['base'] in ("hold"):
-            for shows in self.re_ShowdownAction.finditer(hand.handText):            
+            for shows in self.re_ShowdownAction.finditer(hand.handText):
                 cards = shows.group('CARDS').split(' ')
                 player = self.playerSeatFromPosition('BovadaToFpdb.readShowdownActions', hand.handid, shows.group('PNAME'))
                 hand.addShownCards(cards, player)
@@ -551,4 +551,3 @@ class Bovada(HandHistoryConverter):
 
     def readShownCards(self,hand):
         pass
-        

--- a/pyfpdb/EnetToFpdb.py
+++ b/pyfpdb/EnetToFpdb.py
@@ -2,17 +2,17 @@
 # -*- coding: utf-8 -*-
 #
 #    Copyright 2012, Chaz Littlejohn
-#    
+#
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
 #    (at your option) any later version.
-#    
+#
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 #    GNU General Public License for more details.
-#    
+#
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -46,7 +46,7 @@ class Enet(HandHistoryConverter):
                           'BRKTS': r'(\(dealer\) |\(small blind\) |\(big blind\) |\(dealer\)\(small blind\) |\(dealer\)\(big blind\) | )?',
                            'NUM' : r'.,\d',
                     }
-                    
+
     # translations from captured groups to fpdb info strings
     Lim_Blinds = {      '0.04': ('0.01', '0.02'),         '0.08': ('0.02', '0.04'),
                         '0.10': ('0.02', '0.05'),         '0.20': ('0.05', '0.10'),
@@ -99,14 +99,14 @@ class Enet(HandHistoryConverter):
     re_PlayerInfo   = re.compile(u"""
           ^Seat\s(?P<SEAT>[0-9]+):\s
           (?P<PNAME>.*)\s
-          \((%(LS)s)?(?P<CASH>[%(NUM)s]+)\sin\schips\)""" % substitutions, 
+          \((%(LS)s)?(?P<CASH>[%(NUM)s]+)\sin\schips\)""" % substitutions,
           re.MULTILINE|re.VERBOSE)
 
     re_HandInfo     = re.compile("""
           ^Table\s\'(?P<TABLE>.+?)\s\-\s(?P<LIMIT>No\sLimit|Limit|Pot\sLimit)\)?\'\s
           ((?P<MAX>\d+)-max\s)?
           (?P<PLAY>\(Play\sMoney\)\s)?
-          (Seat\s\#(?P<BUTTON>\d+)\sis\sthe\sbutton)?""", 
+          (Seat\s\#(?P<BUTTON>\d+)\sis\sthe\sbutton)?""",
           re.MULTILINE|re.VERBOSE)
 
     re_Identify     = re.compile(u'^Game\s\#\d+:')
@@ -172,12 +172,12 @@ class Enet(HandHistoryConverter):
             info['bb'] = self.clearMoneyString(mg['BB'])
         if 'CURRENCY' in mg:
             info['currency'] = self.currencies[mg['CURRENCY']]
-                
+
         if 'TOURNO' in mg and mg['TOURNO'] is None:
             info['type'] = 'ring'
         else:
             info['type'] = 'tour'
-            
+
         if not mg['CURRENCY'] and info['type']=='ring':
             info['currency'] = 'play'
 
@@ -192,7 +192,7 @@ class Enet(HandHistoryConverter):
                     raise FpdbParseError
             else:
                 info['sb'] = str((Decimal(self.clearMoneyString(mg['SB']))/2).quantize(Decimal("0.01")))
-                info['bb'] = str(Decimal(self.clearMoneyString(mg['SB'])).quantize(Decimal("0.01")))    
+                info['bb'] = str(Decimal(self.clearMoneyString(mg['SB'])).quantize(Decimal("0.01")))
 
         return info
 
@@ -267,7 +267,7 @@ class Enet(HandHistoryConverter):
                 hand.buttonpos = info[key]
             if key == 'MAX' and info[key] != None:
                 hand.maxseats = int(info[key])
-    
+
     def readButton(self, hand):
         m = self.re_Button.search(hand.handText)
         if m:
@@ -284,7 +284,7 @@ class Enet(HandHistoryConverter):
     def markStreets(self, hand):
 
         # There is no marker between deal and draw in Stars single draw games
-        #  this upsets the accounting, incorrectly sets handsPlayers.cardxx and 
+        #  this upsets the accounting, incorrectly sets handsPlayers.cardxx and
         #  in consequence the mucked-display is incorrect.
         # PREFLOP = ** Dealing down cards **
         # This re fails if,  say, river is missing; then we don't get the ** that starts the river.
@@ -309,13 +309,13 @@ class Enet(HandHistoryConverter):
         for player in m:
             #~ logging.debug("hand.addAnte(%s,%s)" %(player.group('PNAME'), player.group('ANTE')))
             hand.addAnte(player.group('PNAME'), self.clearMoneyString(player.group('ANTE')))
-    
+
     def readBringIn(self, hand):
         m = self.re_BringIn.search(hand.handText,re.DOTALL)
         if m:
             #~ logging.debug("readBringIn: %s for %s" %(m.group('PNAME'),  m.group('BRINGIN')))
             hand.addBringIn(m.group('PNAME'),  self.clearMoneyString(m.group('BRINGIN')))
-        
+
     def readBlinds(self, hand):
         liveBlind = True
         for a in self.re_PostSB.finditer(hand.handText):
@@ -374,7 +374,7 @@ class Enet(HandHistoryConverter):
     def readShowdownActions(self, hand):
 # TODO: pick up mucks also??
         for shows in self.re_ShowdownAction.finditer(hand.handText):
-            cards = shows.group('CARDS')  
+            cards = shows.group('CARDS')
             cards = [cards[i:i+2] for i in range(len(cards)) if i%2==0 and i+2<=len(cards)]
             hand.addShownCards(cards, shows.group('PNAME'))
 
@@ -400,5 +400,5 @@ class Enet(HandHistoryConverter):
                 elif m.group('SHOWED') == "mucked": mucked = True
 
                 #print "DEBUG: hand.addShownCards(%s, %s, %s, %s)" %(cards, m.group('PNAME'), shown, mucked)
-                hand.addShownCards(cards=cards, player=m.group('PNAME'), shown=shown, mucked=mucked, string=string)          
-    
+                hand.addShownCards(cards=cards, player=m.group('PNAME'), shown=shown, mucked=mucked, string=string)
+

--- a/pyfpdb/GuiHandViewer.py
+++ b/pyfpdb/GuiHandViewer.py
@@ -95,7 +95,7 @@ def cash_renderer_cell_func(tree_column, cell, model, tree_iter, data):
     else:
         cell.set_property('foreground', 'darkgreen')
     cell.set_property('text', coldata)
-    
+
 def reset_style_render_func(tree_column, cell, model, iter, data):
     cell.set_property('foreground', None)
     cell.set_property('text', model.get_value(iter, data))
@@ -117,7 +117,7 @@ class GuiHandViewer:
 
         self.db = Database.Database(self.config, sql=self.sql)
 
-        
+
         filters_display = { "Heroes"    : True,
                     "Sites"     : True,
                     "Games"     : True,
@@ -136,7 +136,7 @@ class GuiHandViewer:
                     "Button1"   : True,
                     "Button2"   : False
                   }
-        
+
         self.filters = Filters.Filters(self.db, self.config, self.sql, display = filters_display)
         self.filters.registerButton1Name(_("Load Hands"))
         self.filters.registerButton1Callback(self.loadHands)
@@ -172,7 +172,7 @@ class GuiHandViewer:
         #      table display. Sooner or later we should probably use one or the other.
         self.deck_instance = Deck.Deck(self.config, height=42, width=30)
         card_images = self.init_card_images(self.config)
-       
+
     def init_card_images(self, config):
         suits = ('s', 'h', 'd', 'c')
         ranks = (14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2)
@@ -192,9 +192,9 @@ class GuiHandViewer:
         self.reload_hands(hand_ids)
 
     def get_hand_ids_from_date_range(self, start, end, save_date = False):
-        """Returns the handids in the given date range and in the filters. 
+        """Returns the handids in the given date range and in the filters.
             Set save_data to true if you want to keep the start and end date if no other date is specified through the filters by the user."""
-            
+
         if save_date:
             self.date_from = start
             self.date_to = end
@@ -203,10 +203,10 @@ class GuiHandViewer:
                 self.date_from = None
             if end != self.filters.MAX_DATE:
                 self.date_to = None
-            
+
         if self.date_from != None and start == self.filters.MIN_DATE:
             start = self.date_from
-            
+
         if self.date_to != None and end == self.filters.MAX_DATE:
             end = self.date_to
 
@@ -238,7 +238,7 @@ class GuiHandViewer:
             return 0
 
     def sorthand(self, model, iter1, iter2):
-        hand1 = self.hands[int(model.get_value(iter1, self.colnum['HandId']))]         
+        hand1 = self.hands[int(model.get_value(iter1, self.colnum['HandId']))]
         hand2 = self.hands[int(model.get_value(iter2, self.colnum['HandId']))]
         base1 = hand1.gametype['base']
         base2 = hand2.gametype['base']
@@ -256,7 +256,7 @@ class GuiHandViewer:
 
         a = self.rankedhand(model.get_value(iter1, 0), hand1.gametype['category'])
         b = self.rankedhand(model.get_value(iter2, 0), hand2.gametype['category'])
-        
+
         if a < b:
             return -1
         elif a > b:
@@ -272,20 +272,20 @@ class GuiHandViewer:
             return -1
         elif a > b:
             return 1
-        
+
         return 0
-    
+
     def sort_pos(self, model, iter1, iter2, col):
         a = self.__get_sortable_int_from_pos__(model.get_value(iter1, col))
         b = self.__get_sortable_int_from_pos__(model.get_value(iter2, col))
-        
+
         if a < b:
             return -1
         elif a > b:
             return 1
-        
+
         return 0
-        
+
     def __get_sortable_int_from_pos__(self, pos):
         if pos == 'B':
             return 8
@@ -293,13 +293,13 @@ class GuiHandViewer:
             return 9
         else:
             return int(pos)
-    
+
     def reload_hands(self, handids):
         self.hands = {}
         for handid in handids:
             self.hands[handid] = self.importhand(handid)
         self.refreshHands()
-    
+
     def copyHandToClipboard(self, view, event, hand):
         handText = StringIO()
         hand.writeHand(handText)
@@ -368,7 +368,7 @@ class GuiHandViewer:
         self.view.insert_column_with_data_func(-1, 'Bet', numcell, reset_style_render_func, self.colnum['Bet'])
         self.view.insert_column_with_data_func(-1, 'Net', numcell, cash_renderer_cell_func, self.colnum['Net'])
         self.view.insert_column_with_data_func(-1, 'Game', textcell, reset_style_render_func ,self.colnum['Game'])
-        
+
         self.liststore.set_sort_func(self.colnum['Street0'], self.sorthand)
         self.liststore.set_sort_func(self.colnum['Pos'], self.sort_pos, self.colnum['Pos'])
         self.liststore.set_sort_func(self.colnum['Net'], self.sort_float, self.colnum['Net'])
@@ -400,36 +400,36 @@ class GuiHandViewer:
                 board.extend(hand.board['FLOP'])
                 board.extend(hand.board['TURN'])
                 board.extend(hand.board['RIVER'])
-                
+
                 pre_actions = hand.get_actions_short(hero, 'PREFLOP')
                 post_actions = ''
                 if 'F' not in pre_actions:      #if player hasen't folded preflop
                     post_actions = hand.get_actions_short_streets(hero, 'FLOP', 'TURN', 'RIVER')
-                
-                row = [hand.getStakesAsString(), pos, hand.join_holecards(hero), pre_actions, ' '.join(board), post_actions, str(won), str(bet), 
+
+                row = [hand.getStakesAsString(), pos, hand.join_holecards(hero), pre_actions, ' '.join(board), post_actions, str(won), str(bet),
                        str(net), gt, handid]
-                
+
             elif hand.gametype['base'] == 'stud':
-                third = " ".join(hand.holecards['THIRD'][hero][0]) + " " + " ".join(hand.holecards['THIRD'][hero][1]) 
+                third = " ".join(hand.holecards['THIRD'][hero][0]) + " " + " ".join(hand.holecards['THIRD'][hero][1])
                 #ugh - fix the stud join_holecards function so we can retrieve sanely
                 later_streets= []
                 later_streets.extend(hand.holecards['FOURTH'] [hero][0])
                 later_streets.extend(hand.holecards['FIFTH']  [hero][0])
                 later_streets.extend(hand.holecards['SIXTH']  [hero][0])
                 later_streets.extend(hand.holecards['SEVENTH'][hero][0])
-                
+
                 pre_actions = hand.get_actions_short(hero, 'THIRD')
                 post_actions = ''
                 if 'F' not in pre_actions:
                     post_actions = hand.get_actions_short_streets(hero, 'FOURTH', 'FIFTH', 'SIXTH', 'SEVENTH')
-                    
-                row = [hand.getStakesAsString(), pos, third, pre_actions, ' '.join(later_streets), post_actions, str(won), str(bet), str(net), 
+
+                row = [hand.getStakesAsString(), pos, third, pre_actions, ' '.join(later_streets), post_actions, str(won), str(bet), str(net),
                        gt, handid]
-                
+
             elif hand.gametype['base'] == 'draw':
-                row = [hand.getStakesAsString(), pos, hand.join_holecards(hero,street='DEAL'), hand.get_actions_short(hero, 'DEAL'), None, None, 
+                row = [hand.getStakesAsString(), pos, hand.join_holecards(hero,street='DEAL'), hand.get_actions_short(hero, 'DEAL'), None, None,
                        str(won), str(bet), str(net), gt, handid]
-            
+
             if self.is_row_in_card_filter(row):
                 self.liststore.append(row)
         #self.viewfilter.set_visible_func(self.viewfilter_visible_cb)
@@ -443,12 +443,12 @@ class GuiHandViewer:
     def is_row_in_card_filter(self, row):
         """ Returns true if the cards of the given row are in the card filter """
         #Does work but all cards that should NOT be displayed have to be clicked.
-        card_filter = self.filters.getCards() 
+        card_filter = self.filters.getCards()
         hcs = row[self.colnum['Street0']].split(' ')
-        
+
         if '0x' in hcs:      #if cards are unknown return True
             return True
-        
+
         gt = row[self.colnum['Game']]
 
         if gt not in ('holdem', 'omahahi', 'omahahilo'): return True
@@ -471,7 +471,7 @@ class GuiHandViewer:
             currency="£"
         else:
             currency = hand.gametype['currency']
-            
+
         replayer = GuiReplayer.GuiReplayer(self.config, self.sql, self.main_window)
 
         replayer.currency = currency
@@ -497,7 +497,7 @@ class GuiHandViewer:
 
     '''
     #This code would use pango markup instead of pix for the cards and renderers
-    
+
     def refreshHands(self, handids):
         self.hands = {}
         for handid in handids:
@@ -565,7 +565,7 @@ class GuiHandViewer:
             if hero in hand.pot.committed.keys():
                 bet = hand.pot.committed[hero]
             net = self.get_net_pango_markup(won - bet)
-            
+
             gt =  hand.gametype['category']
             row = []
             if hand.gametype['base'] == 'hold':
@@ -575,7 +575,7 @@ class GuiHandViewer:
                 river = hand.get_cards_pango_markup(hand.board["RIVER"])
                 row = [hole, flop, turn, river, None, net, gt, handid]
             elif hand.gametype['base'] == 'stud':
-                third = hand.get_cards_pango_markup(hand.holecards['THIRD'][hero][0]) + " " + hand.get_cards_pango_markup(hand.holecards['THIRD'][hero][1]) 
+                third = hand.get_cards_pango_markup(hand.holecards['THIRD'][hero][0]) + " " + hand.get_cards_pango_markup(hand.holecards['THIRD'][hero][1])
                 #ugh - fix the stud join_holecards function so we can retrieve sanely
                 fourth  = hand.get_cards_pango_markup(hand.holecards['FOURTH'] [hero][0])
                 fifth   = hand.get_cards_pango_markup(hand.holecards['FIFTH']  [hero][0])

--- a/pyfpdb/MergeStructures.py
+++ b/pyfpdb/MergeStructures.py
@@ -2,17 +2,17 @@
 # -*- coding: utf-8 -*-
 #
 #    Copyright 2010-2013, Chaz Littlejohn
-#    
+#
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
 #    (at your option) any later version.
-#    
+#
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 #    GNU General Public License for more details.
-#    
+#
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -23,12 +23,12 @@ from datetime import datetime
 import pytz
 
 class MergeStructures:
-    
+
     def __init__(self):
         self.versions = [pytz.utc.localize(datetime.strptime(d, "%Y/%m/%d %H:%M:%S")) for d in ("2013/05/28 00:00:00",)]
         self.versions.append(datetime.utcnow().replace(tzinfo = pytz.utc))
         self.SnG_Structures = []
-        self.SnG_Structures.append({  
+        self.SnG_Structures.append({
                             '$1 NL Holdem Double Up - 10 Handed'    : {'buyIn': 1,   'fee': 0.08, 'currency': 'USD', 'seats': 10, 'multi': False, 'payoutCurrency': 'USD', 'payouts': (2,2,2,2,2)},
                             '$1 PL Omaha Double Up - 10 Handed'     : {'buyIn': 1,   'fee': 0.08, 'currency': 'USD', 'seats': 10, 'multi': False, 'payoutCurrency': 'USD', 'payouts': (2,2,2,2,2)},
                             '$10 Bounty SnG - 6 Handed'             : {'buyIn': 5,   'fee': 1,    'currency': 'USD', 'seats': 6, 'multi': False, 'payoutCurrency': 'USD', 'payouts': (21, 9)},
@@ -448,11 +448,9 @@ class MergeStructures:
                             'Turbo 45 Man - $11': {'buyIn': 10.17, 'fee': 0.83, 'currency': 'USD', 'seats': 9, 'max': 45, 'multi': True, 'speed': 'Turbo', 'payoutCurrency': 'USD', 'payouts': (142.79, 97.94, 75.06, 57.21, 40.73, 27.45, 16.47)},
                             'Turbo 45 Man - $5.5': {'buyIn': 5.04, 'fee': 0.46, 'currency': 'USD', 'seats': 9, 'max': 45, 'multi': True, 'speed': 'Turbo', 'payoutCurrency': 'USD', 'payouts': (70.77, 48.54, 37.20, 28.35, 20.18, 13.6, 8.16)},
                             })
-        
+
     def lookupSnG(self, key, startTime):
         for i in range(len(self.versions)):
             if startTime < self.versions[i]:
                 struct = self.SnG_Structures[i].get(key)
                 return struct
-        
-    

--- a/pyfpdb/PokerStarsStructures.py
+++ b/pyfpdb/PokerStarsStructures.py
@@ -2,17 +2,17 @@
 # -*- coding: utf-8 -*-
 #
 #    Copyright 2010-2013, Chaz Littlejohn
-#    
+#
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
 #    (at your option) any later version.
-#    
+#
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 #    GNU General Public License for more details.
-#    
+#
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -23,7 +23,7 @@ from datetime import datetime
 import pytz
 
 class PokerStarsStructures:
-    
+
     def __init__(self):
         self.versions = [pytz.utc.localize(datetime.strptime(d, "%Y/%m/%d %H:%M:%S")) for d in ("2011/05/05 00:00:00","2011/05/20 00:00:00")]
         self.versions.append(datetime.utcnow().replace(tzinfo = pytz.utc))
@@ -309,6 +309,3 @@ class PokerStarsStructures:
             if startTime < self.versions[i]:
                 struct = self.SnG_Structures[i].get(key)
                 return struct
-                                    
-                                    
-                                    

--- a/pyfpdb/PokerTrackerSummary.py
+++ b/pyfpdb/PokerTrackerSummary.py
@@ -30,7 +30,7 @@ class PokerTrackerSummary(TourneySummary):
     hhtype = "summary"
     limits = { 'NL':'nl', 'No Limit':'nl', 'Pot Limit':'pl', 'PL': 'pl', 'FL': 'fl', 'Limit':'fl', 'LIMIT':'fl' }
     games = {                          # base, category
-                              "Hold'em" : ('hold','holdem'), 
+                              "Hold'em" : ('hold','holdem'),
                         "Texas Hold'em" : ('hold','holdem'),
                                "Holdem" : ('hold','holdem'),
                                 'Omaha' : ('hold','omahahi'),
@@ -65,7 +65,7 @@ class PokerTrackerSummary(TourneySummary):
                         """ % substitutions ,re.VERBOSE|re.MULTILINE)
 
     re_Player = re.compile(u"""Place:\s(?P<RANK>[0-9]+),\sPlayer:\s(?P<NAME>.*),\sWon:\s(?P<CUR>[%(LS)s]?)(?P<WINNINGS>[,.0-9]+),( Rebuys: (?P<REBUYS>\d+),)?( Addons: (?P<ADDONS>\d+),)?""" % substitutions)
-    
+
     re_DateTime1    = re.compile("""(?P<Y>[0-9]{4})\-(?P<M>[0-9]{2})\-(?P<D>[0-9]{2})[\- ]+(?P<H>[0-9]+):(?P<MIN>[0-9]+):(?P<S>[0-9]+)""", re.MULTILINE)
     re_DateTime2    = re.compile("""(?P<M>[0-9]{2})\/(?P<D>[0-9]{2})\/(?P<Y>[0-9]{4})[\- ]+(?P<H>[0-9]+):(?P<MIN>[0-9]+):(?P<S>[0-9]+)""", re.MULTILINE)
     re_DateTime3    = re.compile("""(?P<H>[0-9]+):(?P<MIN>[0-9]+):(?P<S>[0-9]+)[\- ]+(?P<Y>[0-9]{4})\/(?P<M>[0-9]{2})\/(?P<D>[0-9]{2})""", re.MULTILINE)
@@ -76,7 +76,7 @@ class PokerTrackerSummary(TourneySummary):
     def getSplitRe(self, head):
         re_SplitTourneys = re.compile("PokerTracker")
         return re_SplitTourneys
-    
+
     def parseSummary(self):
         m = self.re_TourneyInfo.search(self.summaryText)
         if m == None:
@@ -114,7 +114,7 @@ class PokerTrackerSummary(TourneySummary):
         if 'ENTRIES'   in mg:
             self.entries = mg['ENTRIES']
             self.prizepool = int(Decimal(self.clearMoneyString(mg['BUYIN']))) * int(self.entries)
-        if 'DATETIME'  in mg: 
+        if 'DATETIME'  in mg:
             if self.siteName in ('iPoker', 'Microgaming'):
                 m1 = self.re_DateTime1.finditer(mg['DATETIME'])
             elif self.siteName == 'Merge':
@@ -124,7 +124,7 @@ class PokerTrackerSummary(TourneySummary):
         datetimestr = "2000/01/01 00:00:00"  # default used if time not found
         for a in m1:
             datetimestr = "%s/%s/%s %s:%s:%s" % (a.group('Y'), a.group('M'),a.group('D'),a.group('H'),a.group('MIN'),a.group('S'))
-            
+
         self.startTime = datetime.datetime.strptime(datetimestr, "%Y/%m/%d %H:%M:%S") # also timezone at end, e.g. " ET"
 
         if mg['CURRENCY'] == "$":     self.buyinCurrency="USD"
@@ -146,13 +146,13 @@ class PokerTrackerSummary(TourneySummary):
 
             if 'WINNINGS' in mg and mg['WINNINGS'] != None:
                 winnings = int(100*Decimal(mg['WINNINGS']))
-                
+
             if 'REBUYS' in mg and mg['REBUYS']!=None:
                 rebuyCount = int(mg['REBUYS'])
-                
+
             if 'ADDONS' in mg and mg['ADDONS']!=None:
                 addOnCount = int(mg['ADDONS'])
-                
+
             if 'CUR' in mg and mg['CUR'] != None:
                 if mg['CUR'] == "$":     self.currency="USD"
                 elif mg['CUR'] == u"€":  self.currency="EUR"

--- a/pyfpdb/PokerTrackerToFpdb.py
+++ b/pyfpdb/PokerTrackerToFpdb.py
@@ -2,17 +2,17 @@
 # -*- coding: utf-8 -*-
 #
 #    Copyright 2008-2012, Chaz Littlejohn
-#    
+#
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
 #    (at your option) any later version.
-#    
+#
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 #    GNU General Public License for more details.
-#    
+#
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
@@ -45,7 +45,7 @@ class PokerTracker(HandHistoryConverter):
                             'CUR': u"(\$|\xe2\x82\xac|\u20ac||\£|)",
                           'BRKTS': r'(\(button\) |\(small blind\) |\(big blind\) |\(button\) \(small blind\) |\(button\) \(big blind\) )?',
                     }
-                    
+
     # translations from captured groups to fpdb info strings
     Lim_Blinds = {      '0.04': ('0.01', '0.02'),         '0.08': ('0.02', '0.04'),
                         '0.10': ('0.02', '0.05'),         '0.20': ('0.05', '0.10'),
@@ -72,7 +72,7 @@ class PokerTracker(HandHistoryConverter):
 
     limits = { 'NL':'nl', 'No Limit':'nl', 'Pot Limit':'pl', 'PL': 'pl', 'FL': 'fl', 'Limit':'fl', 'LIMIT':'fl' }
     games = {                          # base, category
-                              "Hold'em" : ('hold','holdem'), 
+                              "Hold'em" : ('hold','holdem'),
                         "Texas Hold'em" : ('hold','holdem'),
                                "Holdem" : ('hold','holdem'),
                                 'Omaha' : ('hold','omahahi'),
@@ -84,7 +84,7 @@ class PokerTracker(HandHistoryConverter):
                          'MERGE_GAME #' : ('Merge', 12),
                           '** Game ID ' : ('Microgaming', 20),
                            '** Hand # ' : ('Microgaming', 20)
-             
+
              }
     currencies = { u'€':'EUR', '$':'USD', '':'T$', u'£':'GBP' }
 
@@ -105,7 +105,7 @@ class PokerTracker(HandHistoryConverter):
           )?\s                        # close paren of the stakes
           (?P<DATETIME>.*$)
         """ % substitutions, re.MULTILINE|re.VERBOSE)
-    
+
     re_GameInfo2     = re.compile(u"""
           EverestPoker\sGame\s\#(?P<HID>[0-9]+):\s+
           (?P<TOUR>Tourney\sID:\s(?P<TOURNO>\d+),\s)?
@@ -120,7 +120,7 @@ class PokerTracker(HandHistoryConverter):
           (-\s)?
           (?P<DATETIME>.*$)
         """ % substitutions, re.MULTILINE|re.VERBOSE)
-    
+
     re_GameInfo3     = re.compile(u"""
           (?P<HID>[0-9]+)(\sVersion:\d)?\sstarting\s\-\s(?P<DATETIME>.*$)\s
           \*\*(?P<TOUR>.+(?P<SPEED>(Turbo|Hyper))?\((?P<TOURNO>\d+)\):Table)?\s(?P<TABLE>.+)\s
@@ -133,14 +133,14 @@ class PokerTracker(HandHistoryConverter):
           ^Seat\s(?P<SEAT>[0-9]+):\s
           (?P<PNAME>.*)\s
           \((?P<CURRENCY>%(LS)s)?(?P<CASH>[%(NUM)s]+)(\sin\schips)?\)
-          (?P<BUTTON>\sDEALER)?""" % substitutions, 
+          (?P<BUTTON>\sDEALER)?""" % substitutions,
           re.MULTILINE|re.VERBOSE)
-    
+
     re_PlayerInfo2   = re.compile(u"""
           ^(\-\s)?(?P<PNAME>.*)\s
           sitting\sin\sseat\s(?P<SEAT>[0-9]+)\swith\s
           (%(LS)s)?(?P<CASH>[%(NUM)s]+)
-          (?P<BUTTON>\s?\[Dealer\])?""" % substitutions, 
+          (?P<BUTTON>\s?\[Dealer\])?""" % substitutions,
           re.MULTILINE|re.VERBOSE)
 
     re_HandInfo_Tour     = re.compile("""
@@ -148,7 +148,7 @@ class PokerTracker(HandHistoryConverter):
           (?P<TOUR>\(Tournament:\s(.+)?\sBuy\-In:\s(?P<BUYIN>(?P<BIAMT>[%(LS)s\d\.]+)\+?(?P<BIRAKE>[%(LS)s\d\.]+))\))
           """ % substitutions
           , re.MULTILINE|re.VERBOSE)
-    
+
     re_HandInfo_Cash     = re.compile("""
           ^Table\s(?P<TABLE>[^\n]+)
           (,\sSeats\s(?P<MAX>\d+))?""" % substitutions
@@ -218,10 +218,10 @@ class PokerTracker(HandHistoryConverter):
             tmp = handText[0:200]
             log.error(_("PokerTrackerToFpdb.determineGameType: '%s'") % tmp)
             raise FpdbParseError
-        
+
         self.sitename = self.sites[m.group('SITE')][0]
         self.siteId   = self.sites[m.group('SITE')][1] # Needs to match id entry in Sites database
-        
+
         info = {}
         if self.sitename in ('iPoker', 'Merge'):
             m = self.re_GameInfo1.search(handText)
@@ -233,7 +233,7 @@ class PokerTracker(HandHistoryConverter):
             tmp = handText[0:200]
             log.error(_("PokerTrackerToFpdb.determineGameType: '%s'") % tmp)
             raise FpdbParseError
-        
+
         mg = m.groupdict()
         #print 'DEBUG determineGameType', '%r' % mg
         if 'LIMIT' in mg and mg['LIMIT'] != None:
@@ -259,7 +259,7 @@ class PokerTracker(HandHistoryConverter):
             info['currency'] = self.currencies[mg['CURRENCY']]
         if 'MIXED' in mg:
             if mg['MIXED'] is not None: info['mix'] = self.mixes[mg['MIXED']]
-                
+
         if 'TOUR' in mg and mg['TOUR'] is not None:
             info['type'] = 'tour'
             info['currency'] = 'T$'
@@ -302,11 +302,11 @@ class PokerTracker(HandHistoryConverter):
             print hand.handText
             log.error(_("PokerTrackerToFpdb.readHandInfo: '%s'") % tmp)
             raise FpdbParseError
-        
+
         if self.sitename not in ('Everest', 'Microgaming'):
             info.update(m.groupdict())
         info.update(m2.groupdict())
-        
+
         if self.sitename != 'Everest':
             hand.setUncalledBets(True)
 
@@ -374,10 +374,10 @@ class PokerTracker(HandHistoryConverter):
                                 #FIXME: handle other currencies, play money
                                 log.error(_("PokerTrackerToFpdb.readHandInfo: Failed to detect currency.") + " Hand ID: %s: '%s'" % (hand.handid, info[key]))
                                 raise FpdbParseError
-    
+
                             info['BIAMT'] = info['BIAMT'].strip(u'$€£')
                             info['BIRAKE'] = info['BIRAKE'].strip(u'$€£')
-    
+
                             hand.buyin = int(100*Decimal(info['BIAMT']))
                             hand.fee = int(100*Decimal(info['BIRAKE']))
             if key == 'TABLE':
@@ -407,13 +407,13 @@ class PokerTracker(HandHistoryConverter):
             if key == 'PLAY' and info['PLAY'] is not None and info['PLAY']=='Play':
 #                hand.currency = 'play' # overrides previously set value
                 hand.gametype['currency'] = 'play'
-                
+
         if self.re_FastFold.search(hand.handText):
             hand.fastFold = True
-                
+
         if self.re_Cancelled.search(hand.handText):
             raise FpdbHandPartial(_("Hand '%s' was cancelled.") % hand.handid)
-    
+
     def readButton(self, hand):
         m = self.re_Button.search(hand.handText)
         if m:
@@ -471,7 +471,7 @@ class PokerTracker(HandHistoryConverter):
             #~ logging.debug("hand.addAnte(%s,%s)" %(player.group('PNAME'), player.group('ANTE')))
             self.adjustMergeTourneyStack(hand, player.group('PNAME'), player.group('ANTE'))
             hand.addAnte(player.group('PNAME'), player.group('ANTE'))
-        
+
     def readBlinds(self, hand):
         liveBlind, bb, sb = True, None, None
         for a in self.re_PostSB.finditer(hand.handText):
@@ -503,7 +503,7 @@ class PokerTracker(HandHistoryConverter):
                     hand.addBlind(a.group('PNAME'), 'both', bb)
                 else:
                     hand.addBlind(a.group('PNAME'), 'big blind', bb)
-                    
+
         if self.sitename == 'Microgaming':
             for a in self.re_PostBoth2.finditer(hand.handText):
                 if self.clearMoneyString(a.group('SBBB')) == hand.gametype['sb']:
@@ -526,7 +526,7 @@ class PokerTracker(HandHistoryConverter):
             for a in self.re_PostBoth1.finditer(hand.handText):
                 self.adjustMergeTourneyStack(hand, a.group('PNAME'), a.group('SBBB'))
                 hand.addBlind(a.group('PNAME'), 'both', self.clearMoneyString(a.group('SBBB')))
-            
+
         # FIXME
         # The following should only trigger when a small blind is missing in a tournament, or the sb/bb is ALL_IN
         # see http://sourceforge.net/apps/mantisbt/fpdb/view.php?id=115
@@ -634,13 +634,13 @@ class PokerTracker(HandHistoryConverter):
                 curr_pot = amount
             else:
                 print (_("DEBUG:") + " " + _("Unimplemented %s: '%s' '%s'") % ("readAction", action.group('PNAME'), action.group('ATYPE')))
-                
+
     def allInBlind(self, hand, street, action, actiontype):
         if street in ('PREFLOP', 'DEAL'):
             player = action.group('PNAME')
             if hand.stacks[player]==0:
                 hand.setUncalledBets(True)
-                
+
     def adjustMergeTourneyStack(self, hand, player, amount):
         if self.sitename == 'Merge':
             amount = Decimal(self.clearMoneyString(amount))
@@ -659,7 +659,7 @@ class PokerTracker(HandHistoryConverter):
         else:
             for m in self.re_CollectPot1.finditer(hand.handText):
                 hand.addCollectPot(player=m.group('PNAME'),pot=re.sub(u',',u'',m.group('POT')))
-                
+
     def readShowdownActions(self, hand):
         pass
 
@@ -685,4 +685,3 @@ class PokerTracker(HandHistoryConverter):
 
                 #print "DEBUG: hand.addShownCards(%s, %s, %s, %s)" %(cards, m.group('PNAME'), shown, mucked)
                 hand.addShownCards(cards=cards, player=m.group('PNAME'), shown=shown, mucked=mucked)
- 


### PR DESCRIPTION
Almost *.py was LF line terminators. But, those files CRLF&LF mixed
  BetOnlineToFpdb.py: CRLF & LF mixed
  BovadaToFpdb.py: CRLF & LF mixed
  PokerTrackerSummary.py: CRLF & LF mixed

Those files are CRLF.
  Archive.py: CRLF only
  BovadaSummary.py: CRLF only
  EnetToFpdb.py: CRLF only
  GuiHandViewer.py: CRLF only
  MergeStructures.py: CRLF only
  PokerStarsStructures.py: CRLF only
  PokerTrackerToFpdb.py: CRLF only

This branch fixes:
  Unify LF line terminators for *.py.
  Delete trailing whitespaces.
  Use 'utf-8' instead of UTF-8 for coding magic comment in Archive.py.

Maybe, "git diff --ignore-space-change" is useful for confirm changes.
