### PR TITLE
[Help]-[LogMessages] radio button label "HUD_main.exe" displayed incorrectly

### DIFF
--- a/pyfpdb/GuiLogView.py
+++ b/pyfpdb/GuiLogView.py
@@ -89,7 +89,7 @@ class GuiLogView:
         hb1 = gtk.HBox(False, 0)
         grp = None
         for logf in LOGFILES:
-            rb = gtk.RadioButton(group=grp, label=logf[0], use_underline=True)
+            rb = gtk.RadioButton(group=grp, label=logf[0], use_underline=False)
             if grp is None: grp = rb
             rb.set_active(logf[2])
             rb.connect('clicked', self.__set_logfile, logf[0])


### PR DESCRIPTION
Incorrect radio button label in [Help]-[LogMessages],

Expected: label "HUD_main.exe Log" displayed.
Actual: label "HUDmain.exe Log" displayed.  (omit underscore)

This commit fix it.
