### PR TITLE
FIX sqlite returning non datetime objects

### DIFF
--- a/pyfpdb/Database.py
+++ b/pyfpdb/Database.py
@@ -3498,6 +3498,8 @@ class Database:
                 startTime, endTime = resultDict['starttime'], resultDict['endtime']
             else:
                 startTime, endTime = resultDict['startTime'], resultDict['endTime']
+            if (startTime!=None): startTime = handTime.replace(tzinfo=None)
+            if (endTime!=None): endTime = handTime.replace(tzinfo=None)
                 
             if (startTime == None or t < startTime):
                 q = self.sql.query['updateTourneyStart'].replace('%s', self.sql.query['placeholder'])


### PR DESCRIPTION
I got this error when import a Tourney :

```
Traceback (most recent call last):
  File "./GuiBulkImport.py", line 70, in load_clicked
    (stored, dups, partial, skipped, errs, ttime) = self.importer.runImport()
  File "/Users/marchand/dev/fpdb-chaz/pyfpdb/Importer.py", line 257, in runImport
    (totstored, totdups, totpartial, totskipped, toterrors) = self.importFiles(None)
  File "/Users/marchand/dev/fpdb-chaz/pyfpdb/Importer.py", line 299, in importFiles
    (stored, duplicates, partial, skipped, errors, ttime) = self._import_despatch(self.filelist[f])
  File "/Users/marchand/dev/fpdb-chaz/pyfpdb/Importer.py", line 326, in _import_despatch
    (stored, duplicates, partial, skipped, errors, ttime) = self._import_hh_file(fpdbfile)
  File "/Users/marchand/dev/fpdb-chaz/pyfpdb/Importer.py", line 459, in _import_hh_file
    hand.prepInsert(self.database, printtest = self.settings['testData'])
  File "/Users/marchand/dev/fpdb-chaz/pyfpdb/Hand.py", line 283, in prepInsert
    self.tourneyId = db.getSqlTourneyIDs(self)
  File "/Users/marchand/dev/fpdb-chaz/pyfpdb/Database.py", line 3475, in getSqlTourneyIDs
    result = self.insertTourney(hand.siteId, hand.tourNo, hand.tourneyTypeId, hand.startTime)
  File "/Users/marchand/dev/fpdb-chaz/pyfpdb/Database.py", line 3504, in insertTourney
    print t < startTime
```

It may have been introduced with your last changes in your last commit d48c5771 (Using .replace(tzinfo=None) everywhere).
This simple commit fixes it.
