### PR TITLE
Revert "FIX sqlite returning non datetime objects"

### DIFF
--- a/pyfpdb/Database.py
+++ b/pyfpdb/Database.py
@@ -3498,8 +3498,6 @@ class Database:
                 startTime, endTime = resultDict['starttime'], resultDict['endtime']
             else:
                 startTime, endTime = resultDict['startTime'], resultDict['endTime']
-            if (startTime!=None): startTime = handTime.replace(tzinfo=None)
-            if (endTime!=None): endTime = handTime.replace(tzinfo=None)
                 
             if (startTime == None or t < startTime):
                 q = self.sql.query['updateTourneyStart'].replace('%s', self.sql.query['placeholder'])


### PR DESCRIPTION
Reverts ChazDazzle/fpdb-chaz#13

What we actually want to do is change the sqlite datetime columns from type 'REAL' to type 'datetime'. When retrieving them from the database they will parsed by python as datetime objects.
